### PR TITLE
Remove dependency on `unstable/contract`.

### DIFF
--- a/db/mongodb/basic/driver.rkt
+++ b/db/mongodb/basic/driver.rkt
@@ -3,7 +3,7 @@
          racket/match
          racket/list
          racket/port
-         unstable/contract
+         (only-in racket/tcp port-number?)
          db/mongodb/wire/main
          net/bson
          net/bson/driver

--- a/db/mongodb/wire/driver.rkt
+++ b/db/mongodb/wire/driver.rkt
@@ -1,6 +1,5 @@
 #lang racket/base
-(require unstable/contract
-         racket/tcp
+(require racket/tcp
          racket/match
          racket/local
          racket/contract

--- a/info.rkt
+++ b/info.rkt
@@ -1,4 +1,4 @@
 #lang info
 (define collection 'multi)
-(define deps '("base" "unstable-contract-lib" "web-server-lib" "srfi-lite-lib"))
+(define deps '(("base" #:version "6.2.900.15") "web-server-lib" "srfi-lite-lib"))
 (define build-deps '("eli-tester" "racket-doc" "scribble-lib" "srfi-doc" "web-server-doc"))


### PR DESCRIPTION
Most of the functionality of that library has been moved to `racket/contract`, and `unstable/contract` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2.1. To preserve compatibility, you can create a Racket 6.2.1-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-contract-lib` package, as it will not be part of the main distribution in future versions. If you decide to go with that option, please keep a dependency to `unstable-contract-lib`.
