### PR TITLE
Fix struct macro

### DIFF
--- a/db/mongodb/orm/struct.rkt
+++ b/db/mongodb/orm/struct.rkt
@@ -14,7 +14,7 @@
          ...))
      (with-syntax*
       ([make-struct
-        (format-id stx "make-~a" #'struct)]
+        (format-id #'struct "make-~a" #'struct)]
        [((required? opt ...) ...)
         (stx-map (lambda (opts-stx)
                    (define opts (syntax->list opts-stx))


### PR DESCRIPTION
A small fix. If we try to generate a structure through another macro, we get an error. Corrected to work